### PR TITLE
Adds default volume to tgchat javascript as well

### DIFF
--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -65,6 +65,8 @@ var opts = {
 	'volumeUpdateDelay': 5000, //Time from when the volume updates to data being sent to the server
 	'volumeUpdating': false, //True if volume update function set to fire
 	'updatedVolume': 0, //The volume level that is sent to the server
+	
+	'defaultMusicVolume': 25,
 
 };
 
@@ -604,6 +606,8 @@ $(function() {
 		opts.updatedVolume = newVolume;
 		sendVolumeUpdate();
 		internalOutput('<span class="internal boldnshit">Loaded music volume of: '+savedConfig.smusicVolume+'</span>', 'internal');
+	} else {
+		$('#adminMusic').prop('volume', opts.defaultMusicVolume);
 	}
 
 	(function() {


### PR DESCRIPTION
The original PR wouldn't quite work like you intended, this addition is also needed
Unfortunately existing players volume cookies may be set at 100 if they fiddled with the slider before, and this won't change that, I can't do anything about that. But new players, and players that haven't touched the slider, will get the default properly (which is configurable!)